### PR TITLE
Update error logging for LLM connection failures

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -30,7 +30,7 @@ async def on_message_handler(bot, message) :
                 return
             
             except ConnectionError as ce:
-                logger.error("Impossible de joindre l'API LLM (ConnectionRefused) : {ce}")
+                logger.error(f"Impossible de joindre l'API LLM (ConnectionRefused) : {ce}")
                 await message.reply("Service IA indisponible, veuillez réessayer plus tard.")
                 return
             


### PR DESCRIPTION
## Summary
- fix formatting for `ConnectionRefused` log message

## Testing
- `pytest -q` *(tests skipped: missing async plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684023435ca0832d9aa4bb5dc174e2e0