### PR TITLE
Update env variables

### DIFF
--- a/.env-renameme
+++ b/.env-renameme
@@ -1,6 +1,9 @@
 # Discord Bot Token
 DISCORD_TOKEN="YOUR_BOT_TOKEN_HERE"
-OLLAMA_MODEL="MODEL_NAME"
+# Ollama model identifiers
+OLLAMA_MISTRAL="mistral"
+OLLAMA_QWEN3="qwen:3b"
+OLLAMA_DEEPSEEK_R1="deepseek-coder:instruct"
 LLM_API="http://localhost:11434"
 GOOGLE_CSE_ID="YOUR_GOOGLE_CSE_ID"
 GOOGLE_API_KEY="YOUR_GOOGLE_API_KEY"

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ pip install -r requirements.txt
 The following environment variables are required and must be set in the `.env` file (rename `.env-renameme` to `.env`):
 
 - `DISCORD_TOKEN` - Your Discord bot token obtained from the Discord Developer Portal
-- `OLLAMA_MODEL` - The name of the Ollama model you want to use (e.g. "llama2", "codellama", etc.)
-- `LLM_API` - The API endpoint URL for your Ollama instance (e.g. "http://localhost:11434/api/generate")
+- `OLLAMA_MISTRAL` - The model name used by the Mistral agent
+- `OLLAMA_QWEN3` - The model name used by the Qwen3 agent
+- `OLLAMA_DEEPSEEK_R1` - The model name used by the DeepSeek R1 agent
+- `LLM_API` - The API endpoint URL for your Ollama instance (e.g. "http://localhost:11434")
 
 Refer to the `.env-renameme` template file for the required format. Environment variables must be set before running the application.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-   asyncio_mode = auto
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- update `.env-renameme` to match `config.py`
- document new env variables in README
- fix trailing newline in `pytest.ini`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3971d0f4832db5cf1be01483b55e