### PR TITLE
Fix newline and indentation in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-   asyncio_mode = auto
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- remove leading spaces on `asyncio_mode = auto`
- ensure `pytest.ini` ends with a newline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b3993b3b8832d99a965ffbffbf3fc