### PR TITLE
Remove unused asyncio import from tests

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -8,7 +8,6 @@ sys.path.append(PROJECT_ROOT)
 # tests/test_handlers.py
 
 import pytest
-import asyncio
 from types import SimpleNamespace
 
 from handlers import on_message_handler


### PR DESCRIPTION
## Summary
- remove redundant `asyncio` import from `tests/test_handlers.py`

## Testing
- `pytest -q` *(fails: unexpected value continuation in pytest.ini)*

------
https://chatgpt.com/codex/tasks/task_e_684b39c10f64832d983033093d832371